### PR TITLE
Make Hot Module Replacement actually work

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,10 @@
 import http from 'http';
 import app from './app';
 
-if (module.hot) {
-  module.hot.accept(['./app']);
-}
+let server;
 
-/* istanbul ignore if */
-if (process.env.NODE_ENV !== 'test') {
+const load = () => {
+  // eslint-disable-next-line no-shadow
   const server = http.createServer(app.callback());
   server.on('listening', () => {
     const { address, port } = server.address();
@@ -14,4 +12,17 @@ if (process.env.NODE_ENV !== 'test') {
     console.log('http://%s:%d/ in %s', address, port, process.env.NODE_ENV || 'dev');
   });
   server.listen(process.env.PORT || 3000);
+  return server;
+};
+
+if (module.hot) {
+  module.hot.accept('./app', () => {
+    server.close();
+    server = load();
+  });
+}
+
+/* istanbul ignore if */
+if (process.env.NODE_ENV !== 'test') {
+  server = load();
 }


### PR DESCRIPTION
I had noticed that changes on the API would not be reflected when reloading
the endpoints.

If I understand correctly, when HMR notices the module change it accepts it,
however, it needs to close the previous server and create a new one.
The old server had a reference to the old `app` module and then a new
server is created referencing the newly loaded instance.