### PR TITLE
Refactor Speedometer API to accept many more options

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "neutrino build",
     "start": "neutrino start",
     "start:prod": "neutrino build && node .",
-    "start:debugger": "neutrino build && node inspect .",
+    "start:debugger": "neutrino build && node --inspect .",
     "precommit": "lint-staged",
     "heroku-postbuild": "npm run build"
   },

--- a/src/perf.js
+++ b/src/perf.js
@@ -7,7 +7,7 @@ import _ from 'lodash/fp';
 import { stringify } from 'query-string';
 import { median, quantile } from 'simple-statistics';
 import { getEvolution, getLatestEvolution } from './perf/tmo';
-import fetchTransformSpeedometerData from './perf/speedometer';
+import fetchSpeedometerData from './perf/speedometer';
 import { fetchTelemetryEvolution } from './perf/tmo-wrapper';
 import fetchJson from './fetch/json';
 import channels from './release/channels';
@@ -167,13 +167,11 @@ router
     ctx.body = list;
   })
   .get('/benchmark/speedometer', async (ctx) => {
-    if (Object.keys(ctx.request.query).length === 0) {
-      ctx.throw(
-        400,
-        'The API now requires you to pass the architecture and channel parameters.',
-      );
+    try {
+      ctx.body = await fetchSpeedometerData(ctx.request.query);
+    } catch (e) {
+      ctx.throw(400, e);
     }
-    ctx.body = await fetchTransformSpeedometerData(ctx.request.query);
   })
   .get('/herder', async (ctx) => {
     const { framework } = ctx.request.query;

--- a/src/perf/speedometer.js
+++ b/src/perf/speedometer.js
@@ -1,3 +1,4 @@
+import { stringify } from 'query-string';
 import fetchJson from '../fetch/json';
 
 const AWFY = 'https://arewefastyet.com';
@@ -11,23 +12,35 @@ const generateUrl = (architecture) => {
   };
 };
 
-const CONFIGURATION = {
-  nightly: { Firefox: 14, Chrome: 3 },
-  beta: { Firefox: 62, Chrome: 3 },
+const BROWSER_TO_ID = {
+  Nightly: 14,
+  Beta: 62,
+  Canary: 3,
 };
 
-const absoluteValues = (graph, configuration) => {
-  const modes = {};
-  const modeIds = Object.values(configuration);
-  modeIds.forEach(modeId => modes[modeId] = []);
+const ID_TO_BROWSER = Object.keys(BROWSER_TO_ID).reduce((res, name) => {
+  res[BROWSER_TO_ID[name]] = name;
+  return res;
+}, {});
+
+const absoluteValues = (graph, browsers) => {
+  // Initialize returning structure
+  const result = browsers.reduce((res, name) => {
+    res[name] = {
+      label: name,
+      data: [],
+    };
+    return res;
+  }, {});
+
+  const modeIds = browsers.map(name => BROWSER_TO_ID[name]);
 
   graph.timelist.forEach((date, idx) => {
     // XXX: This flattens all data points for the same day to one data point
     const dayDate = new Date(date * 1000).toISOString().substring(0, 10);
     graph.lines.forEach((line) => {
-      // if (line && line.data[idx] && modeIds.find(el => el === line.modeid)) {
       if (line && line.data[idx] && modeIds.includes(line.modeid)) {
-        modes[line.modeid].push({
+        result[ID_TO_BROWSER[line.modeid]].data.push({
           date: dayDate,
           value: line.data[idx][0],
         });
@@ -35,23 +48,88 @@ const absoluteValues = (graph, configuration) => {
     });
   });
 
-  return modeIds.map(modeId => modes[modeId]);
+  return result;
 };
 
-const fetchTransformSpeedometerData = async ({ architecture, channel }) => {
-  // XXX: We should look into a nicer approach. The 1st represents Chrome & the 2nd Firefox
-  const configuration = CONFIGURATION[channel];
+// In September 2017, we adjusted the benchmark and caused Canary and Firefox
+// to have a new baseline. For this graph we need to drop data before then
+const skipBump = (originalData) => {
+  const newData = {};
+  Object.keys(originalData).forEach((name) => {
+    const { label, data } = originalData[name];
+    newData[name] = {
+      label,
+      data: data.filter((el) => {
+        const date = new Date(el.date);
+        let newEl = null;
+        if (date >= new Date('2017-10-01')) {
+          newEl = el;
+        }
+        return newEl;
+      }),
+    };
+  });
+
+  return newData;
+};
+
+// XXX: In the future we should do many more validations
+const validateParameters = ({ architecture, browser }) => {
+  if (!browser || !architecture) {
+    const message = 'This API requires various parameters. Please refer to the code.';
+    throw Error(message);
+  }
+};
+
+// architecture and browser are required in order to determine what data to show
+// If you pass targetRatio it will add a target line based on Chrome's data
+// If you pass a baseValue we will add a target line based on that value
+// omitOldBaseline skips data points before Sep. 2017
+const fetchSpeedometerData = async ({
+  architecture, browser, targetRatio, baseValue, omitOldBaseline,
+}) => {
+  validateParameters({
+    architecture, browser, targetRatio, baseValue, omitOldBaseline,
+  });
+  // If only one browser specified turn it into an array of one
+  const browsers = (typeof browser === 'string') ? [browser] : browser;
   const { dataUrl, viewUrl } = generateUrl(architecture);
-  const referenceSeries = await fetchJson(dataUrl);
+  const { graph } = await fetchJson(dataUrl);
+  let data = absoluteValues(graph, browsers);
+
+  if (omitOldBaseline) {
+    data = skipBump(data);
+  }
+
+  const canary = data.Canary.data;
+  // We will add one more series representing the target based on Canary's series
+  if (baseValue && targetRatio) {
+    const canaryLastDataPoint = baseValue * targetRatio;
+    data.Target = {
+      label: `Target ${targetRatio * 100}%`,
+      data: new Array([
+        { date: canary[0].date, value: canaryLastDataPoint },
+        { date: canary[canary.length - 1].date, value: canaryLastDataPoint },
+      ]),
+    };
+  } else if (targetRatio) {
+    data.Target = {
+      label: `Target ${targetRatio * 100}%`,
+      data: canary.map(el => ({
+        date: el.date,
+        value: el.value * targetRatio,
+      })),
+    };
+  }
   return {
     meta: {
-      configuration,
       dataUrl,
       viewUrl,
     },
-    legendLabels: Object.keys(configuration),
-    series: absoluteValues(referenceSeries.graph, configuration),
+    data,
   };
 };
 
-export default fetchTransformSpeedometerData;
+// XXX: Add propTypes support
+
+export default fetchSpeedometerData;


### PR DESCRIPTION
A lot of the code added in this change comes from the frontend code.
Instead of doing all sorts of manipulations on the frontend we can
instead rely on the backend to give us the correct data.

This change also allows to simply raise an error and the API will
return the correct message to the user.