### PR TITLE
Modify release/calendar endpoint

### DIFF
--- a/src/release.js
+++ b/src/release.js
@@ -39,7 +39,8 @@ router
   })
 
   .get('/calendar', async (ctx) => {
-    ctx.body = await getCalendar();
+    const query = ctx.request.query;
+    ctx.body = await getCalendar(query);
   })
 
   .get('/chrome', async (ctx) => {

--- a/src/release/calendar.js
+++ b/src/release/calendar.js
@@ -4,28 +4,46 @@ import fetchText from '../fetch/text';
 import { parse } from '../meta/version';
 
 export default async function getCalendar({
-  channel = 'release',
+  channel = 'release', days = 0,
 } = {}) {
   const url = 'https://calendar.google.com/calendar/ical/mozilla.com_2d37383433353432352d3939%40resource.calendar.google.com/public/basic.ics';
   const ics = await fetchText(url);
   const parsed = ical.parseICS(ics);
   const dates = Object.keys(parsed).reduce((data, key) => {
     const entry = parsed[key];
-    if (moment().diff(entry.start, 'days') >= 0) {
+    let regex;
+    let version;
+    let ch;
+    // skip reference to Aurora due to merge into Beta to avoid duplicate entries
+    if (moment().diff(entry.start, 'days') >= days || entry.summary === 'MERGE: B58, A59, N60') {
       return data;
     }
-    const summary = entry.summary.match(/firefox\s+(esr)?\s*([\d.]+)\s+release/i);
+    if (channel === 'release') {
+      regex = /firefox\s+(esr)?\s*([\d.]+)\s+release/i;
+    } else if (channel === 'nightly') {
+      regex = /N[0-9]*/;
+    } else if (channel === 'beta') {
+      regex = /B[0-9]*/;
+    }
+    const summary = entry.summary.match(regex);
+
     if (!summary) {
       return data;
     }
-    const ch = summary[1] ? 'esr' : 'release';
-    if (channel && ch !== channel) {
-      return data;
+
+    if (channel === 'release') {
+      ch = summary[1] ? 'esr' : 'release';
+      if (channel && ch !== channel) {
+        return data;
+      }
+      ({ clean: version } = parse(summary[2]));
+    } else {
+      version = summary.join('').replace(/N|B/, '');
     }
-    const { clean } = parse(summary[2]);
+
     data.push({
-      version: clean,
-      channel: ch,
+      version,
+      channel: !ch ? channel : ch,
       date: moment(entry.start).format('YYYY-MM-DD'),
     });
     return data;


### PR DESCRIPTION
add query string parameters to fetch data for nightly and beta and for any number of days to support [this](https://github.com/mozilla/firefox-health-dashboard/issues/54) feature 