### PR TITLE
Refactor redis setup

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,7 +28,8 @@
     }
   },
   "addons": [
-    "papertrail"
+    "papertrail",
+    "heroku-redis"
   ],
   "buildpacks": [
     {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "author": "Harald Kirschner <npm@digitarald.com> (http://digitarald.de/)",
   "license": "MPL-2.0",
   "dependencies": {
+    "async-redis": "^1.1.4",
     "browserslist": "^2.2.2",
     "caniuse-db": "^1.0.30000712",
     "cheerio": "^1.0.0-rc.2",
@@ -42,10 +43,7 @@
     "moment": "^2.19.3",
     "qs": "^6.5.0",
     "query-string": "^5.0.1",
-    "redis": "^2.7.0",
-    "redis-commands": "^1.3.1",
-    "simple-statistics": "^5.2.0",
-    "then-redis": "^2.0.1"
+    "simple-statistics": "^5.2.0"
   },
   "devDependencies": {
     "@neutrinojs/airbnb-base": "^8.3.0",

--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,7 @@ import responseTime from 'koa-response-time';
 import Router from 'koa-router';
 import cors from 'koa-cors';
 import Koa from 'koa';
-import { createClient } from 'then-redis';
+import { createClient } from 'async-redis';
 
 dotenv.config();
 

--- a/src/fetch/text.js
+++ b/src/fetch/text.js
@@ -1,5 +1,5 @@
 /* global fetch */
-import { createClient } from 'then-redis';
+import asyncRedis from 'async-redis';
 // This is important for being able to use 'fetch-mock' in tests
 // I also switch from node-fetch to isomorphic-fetch to make it work
 // both on node (test run) and the browser (loading the API)
@@ -13,32 +13,61 @@ const defaultTtl = moment.duration(8, 'hours').as('seconds');
 let db = null;
 const devCache = {};
 
-export default async function fetchText(
-  url,
-  { ttl = defaultTtl, headers = {}, method = 'get' } = {},
-) {
-  const key = `cache:${url}`;
+const fetchCall = async (url, { headers = {}, method = 'get' } = {}) => {
+  const response = await fetch(url, { method, headers });
+  if (!response.ok) {
+    console.error(`Response for ${url} not OK: ${response.status}`);
+    return null;
+  }
+  return response.text();
+};
+
+const storeInRedis = async (key, value, { ttl = defaultTtl }) => {
   if (typeof ttl === 'string') {
     ttl = moment.duration(1, ttl).as('seconds');
   }
-  if (process.env.REDIS_URL && !db) {
-    db = createClient(process.env.REDIS_URL);
+  await db.set(key, value);
+  await db.expire(key, ttl);
+};
+
+const redisFetch = async (url, options) => {
+  const key = `cache:${url}`;
+  if (!db) {
+    db = asyncRedis.createClient(process.env.REDIS_URL);
   }
-  const cached = db ? await db.get(key) : devCache[key];
+  const cached = await db.get(key);
   if (cached) {
     return cached;
   }
-  const response = await fetch(url, { method, headers });
-  if (!response.ok) {
-    // console.error(`Response for ${url} not OK: ${response.status}`);
-    return null;
+  const text = await fetchCall(url, options);
+  if (text) {
+    await storeInRedis(key, text, options);
   }
-  const text = await response.text();
+  console.log(text);
+  return text;
+};
+
+const inMemoryFetch = (url, options) => {
+  const key = `cache:${url}`;
+  const cached = devCache[key];
+  if (cached) {
+    return cached;
+  }
+  return fetchCall(url, options);
+};
+
+const fetchText = async (url, options = {}) => {
+  let text;
   if (process.env.REDIS_URL) {
-    db.set(key, text);
-    db.expire(key, ttl);
+    try {
+      text = redisFetch(url, options);
+    } catch (e) {
+      console.error(e);
+    }
   } else {
-    devCache[key] = text;
+    text = inMemoryFetch(url, options);
   }
   return text;
-}
+};
+
+export default fetchText;

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,6 +448,13 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
+async-redis@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/async-redis/-/async-redis-1.1.4.tgz#b6e6f110ad7bcf4fe34b643776b8c5d6c1b00a62"
+  dependencies:
+    redis "^2.8.0"
+    redis-commands "^1.3.1"
+
 async@^1.4.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -5390,7 +5397,7 @@ redis-parser@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
 
-redis@^2.7.0:
+redis@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/redis/-/redis-2.8.0.tgz#202288e3f58c49f6079d97af7a10e1303ae14b02"
   dependencies:
@@ -6246,10 +6253,6 @@ test-exclude@^4.2.0:
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
-
-then-redis@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/then-redis/-/then-redis-2.0.1.tgz#e797f18fff7f3c50bfc2ae95a35db5ad0b0816ff"
 
 through2@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
For some reason, redis was not working for me locally.
Upon further research I noticed that `then-redis` has been depecrated
and we can use `async-redis` to help using async/await.

I refactored the fetchText.js module to separate the logic when
using Redis and when not.