### PR TITLE
Support Chrome beta data in the Nimbledroid API

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,7 +1,7 @@
 const config = {
   quantumSpreadsheetId: '1UMsy_sZkdgtElr2buwRtABuyA3GY6wNK_pfF01c890A',
   androidSpreadsheetId: '1vE0b3tawWY9vVNq9Ds6CiA9XZ6LStkcXZl3F8dwXid8',
-  nimbledroidApiUrl: 'https://nimbledroid.com/api/v2/users/npark@mozilla.com/apps/org.mozilla',
+  nimbledroidApiUrl: 'https://nimbledroid.com/api/v2/users/npark@mozilla.com/apps',
   repoUrl: 'https://github.com/mozilla/firefox-health-backend',
 };
 

--- a/src/scripts/fetchNimbledroidData.js
+++ b/src/scripts/fetchNimbledroidData.js
@@ -53,7 +53,11 @@ const main = async () => {
   let errorCode = -1;
   console.log('Fetching each product can take between 20-40 seconds.');
   try {
-    await Promise.all(['klar', 'focus'].map(async (productName) => {
+    await Promise.all([
+      'org.mozilla.klar',
+      'org.mozilla.focus',
+      'com.chrome.beta',
+    ].map(async (productName) => {
       console.log(`Fetching ${productName}`);
       const productData = await fetchData(productName);
       console.log(`Storing ${productName}`);

--- a/src/utils/NimbledroidClient/index.js
+++ b/src/utils/NimbledroidClient/index.js
@@ -1,7 +1,7 @@
 import fetchJson from '../../fetch/json';
 import config from '../../configuration';
 
-const apiUrl = product => `${config.nimbledroidApiUrl}.${product}/apks`;
+const apiUrl = product => `${config.nimbledroidApiUrl}/${product}/apks`;
 
 const generateAuthKey = (email, apiKey) => (
   Buffer.from(`${email}:${apiKey}`).toString('base64')


### PR DESCRIPTION
We want to display in the UI Chrome beta data:
https://github.com/mozilla/firefox-health-dashboard/issues/133

This makes the fetching script also store data for Chrome beta.

This also changes the endpoint to require calling it with "?product=org.mozilla.focus"
rather than "?product=focus".