### PR TITLE
add another platform to nimbledroid.  some more .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist
 *.log
 build/
 dump.rdb
+/.idea
+/*.iml

--- a/src/scripts/fetchNimbledroidData.js
+++ b/src/scripts/fetchNimbledroidData.js
@@ -61,6 +61,7 @@ const main = async () => {
   try {
     await Promise.all([
       'org.mozilla.fenix',
+      'org.mozilla.fenix.nightly',
       'org.mozilla.reference.browser',
       'org.mozilla.geckoview_example',
       'com.chrome.beta',


### PR DESCRIPTION
I am not certain if the Nimbledroid backend is still working.  If it is, then this should pull the new data.

https://github.com/mozilla/firefox-health-backend/issues/71

https://github.com/mozilla-frontend-infra/firefox-health-dashboard/issues/591

